### PR TITLE
Generating ARN strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ var/
 # tests artifacts
 .cache
 .pytest_cache
+
+# editor files
+*~
+.#*
+\#*#

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
+  - "3.5" 
   - "3.6"
-  - "3.6-dev" # 3.6 development branch
+  - "3.6" # 3.6 development branch
   - "3.7-dev" # 3.7 development branch
+  - "3.8-dev" # 3.7 development branch
   - "nightly" # currently points to 3.7-dev
 before_install:
   - pip install --upgrade pytest

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ publish-test: clean build
 
 publish: clean build
 	@twine upload --repository pypi dist/*
+
+test:
+	python -m nose

--- a/arnparse/arnparse.py
+++ b/arnparse/arnparse.py
@@ -20,6 +20,13 @@ class Arn(object):
         self.resource_type = resource_type
         self.resource = resource
 
+    def __str__(self):
+        if self.resource_type is None:
+            rtype_part  = ""
+        else:
+            rtype_part  = self.resource_type + "/"
+        return "arn:" + ":".join(["" if x is None else x for x in [self.partition, self.service, self.region, self.account_id]]) + ":" + rtype_part + self.resource 
+
 
 def arnparse(arn_str):
     if not arn_str.startswith('arn:'):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-mock
+hypothesis

--- a/tests/test_arngenerate.py
+++ b/tests/test_arngenerate.py
@@ -1,0 +1,22 @@
+from hypothesis import given
+from hypothesis.strategies import sampled_from
+
+from arnparse import arnparse
+
+# ARN examples from https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md
+# under Apache2 license
+
+arn_examples = (
+    "arn:aws:serverlessrepo:us-east-1:012345678901:applications/my-application",
+    "arn:aws:sns:us-east-1:123456789012:my_topic",
+    "arn:aws:kinesis:us-east-1:123456789012:stream/my-stream",
+    "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2016-08-11T21:21:33.291",
+    "arn:aws:sqs:us-west-2:012345678901:my-queu",
+    "arn:aws:serverlessrepo:us-east-1:012345678901:applications/my-application",
+    "arn:aws:iam::123456789012:role/S3Access",
+    "arn:aws:s3:::my-bucket/*",
+)
+
+@given(sampled_from(arn_examples))
+def test_arn_to_string(arn):
+    assert str(arnparse(arn)) == arn


### PR DESCRIPTION
This is a first run through generating ARNs - adds a `__str__` method to the ARN object as discussed in https://github.com/PokaInc/arnparse/issues/6

